### PR TITLE
feat: add ignore config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ rules:
     level: off
   slave:
     level: failure
+ignore:
+ - ".github/in-solidarity.yml"  # default
+ - "**/*.yml"
 ```
 
 The rule names are in [rules.ts](https://github.com/jpoehnelt/in-solidarity-bot/blob/main/src/rules.ts).

--- a/fixtures/in-solidarity.yml
+++ b/fixtures/in-solidarity.yml
@@ -1,3 +1,6 @@
 rules:
   master:
     level: off
+ignore:
+ - ".github/in-solidarity.yml"
+ - "**/*.yml"

--- a/fixtures/pull.failing.diff
+++ b/fixtures/pull.failing.diff
@@ -6,3 +6,11 @@ index 83c831f..32091b9 100644
  # test
 +whitelist
 +Master
+diff --git a/.github/in-solidarity.yml b/.github/in-solidarity.yml
+index 83c831f..32091b9 100644
+--- a/.github/in-solidarity.yml
++++ b/.github/in-solidarity.yml
+@@ -1 +1,3 @@
+ # test
++whitelist
++Master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1508,6 +1508,11 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
       "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+    },
     "@types/nock": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@types/nock/-/nock-11.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "testEnvironment": "node"
   },
   "dependencies": {
+    "@types/minimatch": "^3.0.3",
     "ajv": "^6.12.3",
     "deepmerge": "^4.2.2",
     "gitdiff-parser": "^0.2.2",
     "js-yaml": "^3.14.0",
+    "minimatch": "^3.0.4",
     "probot": "^9.13.0"
   },
   "devDependencies": {

--- a/src/annotate.test.ts
+++ b/src/annotate.test.ts
@@ -14,22 +14,23 @@
  * limitations under the License.
  */
 
-import { DEFAULT_RULES, Level } from "./rules";
 import { annotate, getLevelFromAnnotations } from "./annotate";
 
+import { DEFAULT_CONFIGURATION } from "./config";
+import { Level } from "./rules";
 import { Octokit } from "@octokit/rest/";
 import fs from "fs";
 import { parse } from "./parse";
 
 test("should ignore existing lines", () => {
   const files = parse(fs.readFileSync("./fixtures/pull.normal.diff", "utf8"));
-  const annotations = annotate({ rules: DEFAULT_RULES }, files);
+  const annotations = annotate(DEFAULT_CONFIGURATION, files);
   expect(annotations).toEqual([]);
 });
 
 test("should annotate correctly", () => {
   const files = parse(fs.readFileSync("./fixtures/pull.failing.diff", "utf8"));
-  const annotations = annotate({ rules: DEFAULT_RULES }, files);
+  const annotations = annotate(DEFAULT_CONFIGURATION, files);
   expect(annotations).toEqual([
     {
       annotation_level: "warning",

--- a/src/annotate.ts
+++ b/src/annotate.ts
@@ -18,6 +18,7 @@ import { Configuration } from "./config";
 import { File } from "gitdiff-parser";
 import { Level } from "./rules";
 import { Octokit } from "@octokit/rest/";
+import minimatch from "minimatch";
 
 export const annotate = (
   config: Configuration,
@@ -26,6 +27,10 @@ export const annotate = (
   const annotations: Octokit.ChecksUpdateParamsOutputAnnotations[] = [];
 
   for (const f of files) {
+    if (config.ignore.some((pattern) => minimatch(f.newPath, pattern))) {
+      continue;
+    }
+
     for (const h of f.hunks) {
       for (const change of h.changes) {
         if (change.isInsert) {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -31,6 +31,7 @@ test("should override default rules", async () => {
     level: "off",
     regex: [/master/gi],
   });
+  expect(config.ignore).toEqual([".github/in-solidarity.yml", "**/*.yml"]);
 });
 
 test("should throw for invalid config", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,11 +23,13 @@ import deepmerge from "deepmerge";
 
 export interface Configuration {
   rules: { [key: string]: Rule };
+  ignore: string[];
 }
 export class InvalidConfigError extends Error {}
 
 export const DEFAULT_CONFIGURATION: Configuration = {
   rules: DEFAULT_RULES,
+  ignore: [".github/in-solidarity.yml"],
 };
 
 const CONFIG_FILE = "in-solidarity.yml";
@@ -53,6 +55,10 @@ const schema = {
       type: "object",
       additionalProperties: false,
       properties: rulesPropertiesSchema,
+    },
+    ignore: {
+      type: "array",
+      items: { type: "string" },
     },
   },
 };

--- a/src/solidarity.test.ts
+++ b/src/solidarity.test.ts
@@ -17,7 +17,7 @@
 import { Conclusion, OutputTitle, Solidarity } from "./solidarity";
 
 import { Context } from "probot";
-import { DEFAULT_RULES } from "./rules";
+import { DEFAULT_CONFIGURATION } from "./config";
 import { LoggerWithTarget } from "probot/lib/wrap-logger";
 import fs from "fs";
 import { parse } from "./parse";
@@ -34,7 +34,7 @@ test("solidarity should run check on failing diff", async () => {
   );
 
   s.diff = jest.fn().mockReturnValue(failingDIff);
-  s.config = { rules: DEFAULT_RULES };
+  s.config = DEFAULT_CONFIGURATION;
 
   const { conclusion, output } = await s.check();
   expect(conclusion).toBe(Conclusion.NEUTRAL);


### PR DESCRIPTION
The config may now specify an ignore field.

```
ignore:
 - ".github/in-solidarity.yml"  # default
 - "**/*.yml"
```


closes #54 