### PR TITLE
fix: code coverage badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Install](https://img.shields.io/badge/-Install%20App-blue)](https://github.com/apps/in-solidarity)
 ![Build](https://github.com/jpoehnelt/in-solidarity-bot/workflows/Build/badge.svg)
 ![Release](https://github.com/jpoehnelt/in-solidarity-bot/workflows/Release/badge.svg)
-[![codecov](https://codecov.io/gh/jpoehnelt/in-solidarity-bot/branch/master/graph/badge.svg)](https://codecov.io/gh/jpoehnelt/in-solidarity-bot)
+[![codecov](https://codecov.io/gh/jpoehnelt/in-solidarity-bot/branch/main/graph/badge.svg)](https://codecov.io/gh/jpoehnelt/in-solidarity-bot)
 ![GitHub contributors](https://img.shields.io/github/contributors/jpoehnelt/in-solidarity-bot?color=green)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![npm](https://img.shields.io/npm/v/in-solidarity-bot)](https://www.npmjs.com/package/in-solidarity-bot)


### PR DESCRIPTION
The badge is loaded from `master` branch. 
It needs to use `main` branch instead.

Fixes #223 🦕
