### PR TITLE
feat(rule): add new rule for 'dummy'

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,7 @@ The following are the default rules.
 |[grandfathered](rules/grandfathered.md)  | `warning`  |
 |[sanity_check](rules/sanity_check.md)  | `warning`  |
 |[man_hours](rules/man_hours.md)  | `warning`  |
+|[dummy](rules/dummy.md)  | `warning`  |
 
 > **Note**: Additional rules are welcome and can be added in [src/rules.ts](https://github.com/jpoehnelt/in-solidarity-bot/blob/main/src/rules.ts).
 

--- a/docs/rules/dummy.md
+++ b/docs/rules/dummy.md
@@ -1,0 +1,31 @@
+# Rule: `dummy`
+
+This rule uses the following patterns: 
+* `/dummy/gi`
+
+It has a default check level of: `warning`
+
+## Alternatives
+* `placeholder`
+* `indicator`
+
+## Configuration
+
+This check level of this rule can be modified with the following:
+
+```yml
+rules:
+  dummy:
+    level: failure
+```
+
+Available levels: 
+
+* `off`
+* `notice`
+* `warning`
+* `failure`
+
+Additional rules and configuration options are at [docs/README.md](../README.md).
+
+_This document is generated from a template using [rules.ts](https://github.com/jpoehnelt/in-solidarity-bot/blob/main/src/rules.ts) and [docs/index.ts](https://github.com/jpoehnelt/in-solidarity-bot/blob/main/docs/index.ts)._

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -167,6 +167,24 @@
               "type": "string"
             }
           }
+        },
+        "dummy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/level"
+            },
+            "alternatives": {
+              "$ref": "#/definitions/alternatives"
+            },
+            "regex": {
+              "$ref": "#/definitions/regex"
+            },
+            "message": {
+              "type": "string"
+            }
+          }
         }
       },
       "additionalProperties": {

--- a/src/__snapshots__/solidarity.test.ts.snap
+++ b/src/__snapshots__/solidarity.test.ts.snap
@@ -63,6 +63,13 @@ rules:
     alternatives:
       - person-hours
       - human-hours
+  dummy:
+    regex:
+      - /dummy/gi
+    level: warning
+    alternatives:
+      - placeholder
+      - indicator
 ignore:
   - .github/in-solidarity.yml
 defaultMessage: >

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -79,4 +79,9 @@ export const DEFAULT_RULES: { [key: string]: Rule } = {
     level: Level.WARNING,
     alternatives: ["person-hours", "human-hours"],
   },
+  dummy: {
+    regex: [/dummy/gi],
+    level: Level.WARNING,
+    alternatives: ["placeholder", "indicator"],
+  },
 };


### PR DESCRIPTION
The word 'dummy' is used in programming in varying contexts. e.g. dummy variable, dummy text, etc